### PR TITLE
feat: Warning the user about non-HTTPS

### DIFF
--- a/src/OptiHPLCHandler/empower_api_core.py
+++ b/src/OptiHPLCHandler/empower_api_core.py
@@ -1,4 +1,5 @@
 import getpass
+import warnings
 from typing import Optional
 
 import keyring
@@ -96,5 +97,7 @@ class EmpowerConnection:
         ):  # If no keyring is available, ask for password. This is the case in Datalab.
             password = None
         if not password:
+            if not self.address.startswith("https"):
+                warnings.warn("The password will be sent in plain text.")
             password = getpass.getpass("Please enter your password: ")
         return password


### PR DESCRIPTION
If the user is about to enter their password and it will be sent over a non-encrypted channel, warn them.