### PR TITLE
feat: New plate type definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ sample_list = [
 ]
 ```
 
-You also need to set the list of plates used in the sampleset
+You also need to set the list of plates used in the sampleset:
 
 ```
 plates = {"1": "plate_1_type_name", "2": "plate_2_type_name"}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ sample_list = [
 ]
 ```
 
+You also need to set the list of plates used in the sampleset
+
+```
+plates = {"1": "plate_1_type_name", "2": "plate_2_type_name"}
+```
+
 At the moment, only Injection Sampleset lines are supported, but the injection volume
 can be set to 0.
 
@@ -67,12 +73,10 @@ You can then use the handler to create the sampleset:
 handler.PostExperiment(
     sample_set_method_name="test_sampleset_method_name",
     sample_list=sample_list,
-    plate_list=[],
+    plates=plates,
     audit_trail_message="test_audit_trail_message",
 )
 ```
-
-Note that `plate_list` should be filled out in order to run the sampleset.
 
 You can run a sampleset method to create a sampleset:
 

--- a/README.md
+++ b/README.md
@@ -58,14 +58,21 @@ sample_list = [
 ]
 ```
 
+At the moment, only Injection Sampleset lines are supported, but the injection volume
+can be set to 0.
+
 You also need to set the list of plates used in the sampleset:
 
 ```
 plates = {"1": "plate_1_type_name", "2": "plate_2_type_name"}
 ```
 
-At the moment, only Injection Sampleset lines are supported, but the injection volume
-can be set to 0.
+You can also have the plate liste be empty, but you will then have to fill it out in
+Empower before you can run the SampleSetMethod:
+
+```
+plates = {}
+```
 
 You can then use the handler to create the sampleset:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
   { name="Søren Furbo", email="srfu@novonordisk.com" },
 ]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: BSD License",

--- a/src/OptiHPLCHandler/empower_handler.py
+++ b/src/OptiHPLCHandler/empower_handler.py
@@ -76,7 +76,7 @@ class EmpowerHandler(StatefulInstrumentHandler[HplcResult, HPLCSetup]):
         self,
         sample_set_method_name: str,
         sample_list: List[Sample],
-        plate_list: List[Any],
+        plates: Dict[str,str],
         audit_trail_message: str,
     ):
         """
@@ -105,16 +105,19 @@ class EmpowerHandler(StatefulInstrumentHandler[HplcResult, HPLCSetup]):
             values, this will errouneously be set to string. Instead, use
                 `"value": {"member": “No”}` or `"value": {"member": “Yes”}`
 
-        :param plate_list: List of plates to use. Each plate is a dictionary with the
-            following keys:
-            - plateTypeName: Name of the plate type
-            - position: Position of the plate in the autosampler. This is what you
-                reference in the sample value "SamplePos"
+        :param plate_list: Dict of plates to use. The keys should be the position of the
+            plate, the value should be the plate type.
 
         :param audit_trail_message: Message to add to the audit trail of the sample set
             method
         """
         logger.debug("Posting experiment to Empower")
+        plate_list = []
+        for (plate_pos, plate_name) in plates.items():
+            plate_list.append({
+                "plateTypeName": plate_name,
+                "plateLayoutPosition": plate_pos,
+            })        
         sampleset_object = {"plates": plate_list, "name": sample_set_method_name}
         empower_sample_list = []
         for num, sample in enumerate(sample_list):

--- a/src/OptiHPLCHandler/empower_handler.py
+++ b/src/OptiHPLCHandler/empower_handler.py
@@ -76,7 +76,7 @@ class EmpowerHandler(StatefulInstrumentHandler[HplcResult, HPLCSetup]):
         self,
         sample_set_method_name: str,
         sample_list: List[Sample],
-        plates: Dict[str,str],
+        plates: Dict[str, str],
         audit_trail_message: str,
     ):
         """
@@ -113,11 +113,13 @@ class EmpowerHandler(StatefulInstrumentHandler[HplcResult, HPLCSetup]):
         """
         logger.debug("Posting experiment to Empower")
         plate_list = []
-        for (plate_pos, plate_name) in plates.items():
-            plate_list.append({
-                "plateTypeName": plate_name,
-                "plateLayoutPosition": plate_pos,
-            })        
+        for plate_pos, plate_name in plates.items():
+            plate_list.append(
+                {
+                    "plateTypeName": plate_name,
+                    "plateLayoutPosition": plate_pos,
+                }
+            )
         sampleset_object = {"plates": plate_list, "name": sample_set_method_name}
         empower_sample_list = []
         for num, sample in enumerate(sample_list):

--- a/tests/test_proxy_api.py
+++ b/tests/test_proxy_api.py
@@ -148,11 +148,10 @@ class TestEmpowerHandler(unittest.TestCase):
             plates=plates,
             audit_trail_message="test_audit_trail_message",
         )
-        plate_definition_list = [{
-                "plateTypeName": plate_name,
-                "plateLayoutPosition": plate_pos}
-                for (plate_pos, plate_name) in plates.items()
-        ]  
+        plate_definition_list = [
+            {"plateTypeName": plate_name, "plateLayoutPosition": plate_pos}
+            for (plate_pos, plate_name) in plates.items()
+        ]
         for plate_definiton in plate_definition_list:
             assert plate_definiton in mock_requests.post.call_args[1]["json"]["plates"]
 


### PR DESCRIPTION
`plates = {"1": "plate_1_type_name", "2": "plate_2_type_name"}` instead of

```
plate_list = [
    {
      "plateTypeName": "string",
      "plateLayoutPosition": "1",
    },
    {
      "plateTypeName": "string",
      "plateLayoutPosition": "2",
    },
]
```