### PR TITLE
Connection update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,4 @@ jobs:
       - run: git push --set-upstream origin release
       - run: python -m bumpver update --${{ inputs.release_type }}
       - run: gh pr create --title "Release" --body "Release" --base main --head release --repo ${{ github.repository }}
-      - run: gh pr merge --rebase --delete-branch --admin
+      - run: gh pr merge --rebase --delete-branch --auto

--- a/src/OptiHPLCHandler/empower_api_core.py
+++ b/src/OptiHPLCHandler/empower_api_core.py
@@ -74,25 +74,6 @@ class EmpowerConnection:
         response.raise_for_status()
         return response
 
-    def put(self, endpoint: str, body: dict) -> requests.Response:
-        logger.debug("Putting %s to %s", body, endpoint)
-        response = requests.put(
-            self.address + endpoint,
-            json=body,
-            headers={"Authorization": "Bearer " + self.token},
-        )
-        if response.status_code == 401:
-            logger.debug("Token expired, logging in again")
-            self.login()
-            response = requests.put(
-                self.address + endpoint,
-                json=body,
-                headers={"Authorization": "Bearer " + self.token},
-            )
-        logger.debug("Got respones %s from %s", response.text, endpoint)
-        response.raise_for_status()
-        return response
-
     def post(self, endpoint: str, body: dict) -> requests.Response:
         logger.debug("Posting %s to %s", body, endpoint)
         response = requests.post(

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -101,13 +101,6 @@ class TestEmpowerConnection(unittest.TestCase):
         )
         # The last call should be to log in, since this should casue an exception.
 
-    @patch("OptiHPLCHandler.empower_api_core.requests")
-    def test_put_http_error(self, mock_requests):
-        mock_response = MagicMock()
-        mock_response.status_code = 400
-        mock_requests.put.return_value = mock_response
-        self.connection.put("test_url", body="test_body")
-        assert mock_requests.put.return_value.raise_for_status.called
 
     @patch("OptiHPLCHandler.empower_api_core.getpass.getpass")
     @patch("OptiHPLCHandler.empower_api_core.requests")
@@ -117,11 +110,10 @@ class TestEmpowerConnection(unittest.TestCase):
         mock_response.json.return_value = {"results": [{"token": "test_token"}]}
         mock_response.status_code = 401
         mock_requests.post.return_value = mock_response
-        mock_requests.put.return_value = mock_response
         mock_getpass.return_value = self.mock_password
         try:  # When put fails, the connection will try and log in, which should also give an error.
             # We do not care about that error, we want to verify that it tries to log in again.
-            self.connection.put("test_url", body="test_body")
+            self.connection.post("test_url", body="test_body")
         except IOError:
             pass
         assert mock_requests.method_calls[-1].args == (

--- a/tests/test_proxy_api.py
+++ b/tests/test_proxy_api.py
@@ -36,8 +36,12 @@ class TestEmpowerHandler(unittest.TestCase):
     def test_empower_handler_initialisation(self):
         assert self.handler.project == "test_project"
         assert self.handler.username == "test_username"
-        assert self.handler.address == "http://test_address/"
-        assert self.handler.connection.address == "http://test_address/"
+        assert (
+            self.handler.address == "http://test_address"
+        )  # Check that the trailing slash is removed
+        assert (
+            self.handler.connection.address == "http://test_address"
+        )  # Check that the trailing slash is removed
         assert self.handler.connection.username == "test_username"
         assert self.handler.connection.project == "test_project"
         assert self.handler.connection.service == "test_service"


### PR DESCRIPTION
* Removed put from EmpowerConnection, since we never want to change data already in Empower.
* More flexibility with address and endpoint: They can start and end, respectively, with or without a slash.
* Tried a new thing with release workflow.