### PR TITLE
Pypi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,4 +86,4 @@ jobs:
       - name: Uploading to pypi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://test.pypi.org/
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,11 @@ jobs:
           python-version: 3.9
       - run: pip install .[build]
       - run: python -m build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wheel
           path: dist/*.whl
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -74,14 +74,14 @@ jobs:
       id-token: write
     steps:
       - name: Downloading wheel
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: wheel
       - name: Downloading sdist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: sdist
       - name: Uploading to pypi
-        uses: pypa/gh-action-pypi-publish@release-v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,8 @@ jobs:
   build:
     name: Build python package
     runs-on: ubuntu-latest
-    # needs: [lint, test, github_release]
-    # if: github.ref == 'refs/heads/main' # Only run on main branch
+    needs: [lint, test, github_release]
+    if: github.ref == 'refs/heads/main' # Only run on main branch
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -85,5 +85,3 @@ jobs:
           path: dist/
       - name: Uploading to pypi
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
   github_release:
-    name: Github release # This is not a separate wokflow because it should only run after linting and testing.
+    name: Version bump and Github release # This is not a separate wokflow because it should only run after linting and testing.
     runs-on: ubuntu-latest
     needs: [lint, test]
     if: github.ref == 'refs/heads/main' # Only run on main branch
@@ -77,11 +77,13 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: wheel
+          path: dist/
       - name: Downloading sdist
         uses: actions/download-artifact@v3
         with:
           name: sdist
+          path: dist/
       - name: Uploading to pypi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
     uses: ./.github/workflows/lint.yml
   test:
     uses: ./.github/workflows/test.yml
-  release:
-    name: Release # This is not a separate wokflow because it should only run after linting and testing.
+  github_release:
+    name: Github release # This is not a separate wokflow because it should only run after linting and testing.
     runs-on: ubuntu-latest
     needs: [lint, test]
     if: github.ref == 'refs/heads/main' # Only run on main branch
@@ -42,3 +42,46 @@ jobs:
           gh pr create --title "Release $CURRENT_VERSION" --body "Release $CURRENT_VERSION" --base main --head release --repo ${{ github.repository }} --reviewer SRFU-NN
           gh pr merge --merge --delete-branch --auto
           gh release create $CURRENT_VERSION --title $CURRENT_VERSION --notes "Release $CURRENT_VERSION" --verify-tag --target $GIT_HASH
+  build:
+    name: Build python package
+    runs-on: ubuntu-latest
+    # needs: [lint, test, github_release]
+    # if: github.ref == 'refs/heads/main' # Only run on main branch
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - run: pip install .[build]
+      - run: python -m build
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheel
+          path: dist/*.whl
+      - uses: actions/upload-artifact@v2
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+  pypi_release:
+    name: PyPI Release
+    runs-on: ubuntu-latest
+    needs: [build]
+    # Specifying an environment, since upload to PyPI is only allowed from the release
+    # environment. NOTE: do NOT use this environemnt for anything else, including build,
+    # as this would be a security risk.
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Downloading wheel
+        uses: actions/download-artifact@v2
+        with:
+          name: wheel
+      - name: Downloading sdist
+        uses: actions/download-artifact@v2
+        with:
+          name: sdist
+      - name: Uploading to pypi
+        uses: pypa/gh-action-pypi-publish@release-v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -207,12 +207,7 @@ Then manually run the
 by clicking `Run workflow`. Select what type of release it is (`patch`, `minor`, or
 `major`) in `The type of release to perform`, and then click `Run workflow`.
 
-Fetch the new tag. Run the commands
+The workflow should create a branch, a tag, a pull request, a Github release and a pypi
+release.
 
-```
-rm -r -fo dist
-py -m build
-py -m twine upload dist/*
-```
-
-you will be prompted for your pipy.org username and password.
+After the workflow is done, you need to approve the pull request.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,6 @@ dev = [
   "black[jupyter]==23.3.0",
   "flake8==6.1.0",
   "isort==5.12.0",
-  "twine==4.0.2",
-  "build==0.10.0",
 ]
 test = [
   "pytest==7.3.1",
@@ -47,6 +45,9 @@ lint = [
 ]
 release = [
   "bumpver==2023.1125",
+]
+build = [
+  "build==0.10.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Topic :: Scientific/Engineering :: Chemistry",
   "Topic :: Software Development :: Libraries :: Python Modules"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
   { name="Søren Furbo", email="srfu@novonordisk.com" },
 ]
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
Added build and pypi release to pipeline

Works with test.pypi.org

We still need to test the built artifacts. It should be doable from downloading them into a job, and running some tests, but which? Getting the entire repo and re-running all tests, or just a select few?

Also extended testing to python 3.10 and 3.11

@Firefly78 , let's look at it tomorrow, if you have time

@sqbl : Mostly FYI for you, I think this is a good model for what we should do with ProcessOptimizer