### PR TITLE
Api version fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Simplified proxy API for interacting with the Waters Empower Web API. It aims to
 putting data into and getting data out of Empower easy, with the aim of automating
 running samples. It will not feature changing data already in Empower.
 
+Version 2.0.0 of OptiHPLCHandler and up is compatible with version 2.1.0.1 and up of the
+Empower web API. For use with older version of the Empower Web API, please use
+OptiHPLCHandler version 1.X.X.
+
 ## Using the package
 
 The package can be installed into a Python environment with the command

--- a/src/OptiHPLCHandler/empower_api_core.py
+++ b/src/OptiHPLCHandler/empower_api_core.py
@@ -91,8 +91,8 @@ class EmpowerConnection:
             json=body,
         )
         reply.raise_for_status()
-        self.token = reply.json()["results"][0]["token"]
-        self.session_id = reply.json()["results"][0]["id"]
+        self.token = reply.json()["result"]["token"]
+        self.session_id = reply.json()["result"]["id"]
         logger.debug("Login successful, keeping token")
 
     def logout(self) -> None:

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -30,15 +30,13 @@ class TestEmpowerConnection(unittest.TestCase):
 
     @patch("OptiHPLCHandler.empower_api_core.requests")
     def test_auto_service(self, mock_requests):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "results": [{"netServiceName": "auto_test_service"}],
-            "result": {"token": "test_token"},
+        mock_response_service = MagicMock()
+        mock_response_service.json.return_value = {
+            "results": [{"netServiceName": "auto_test_service"}]
         }
-        mock_response.status_code = 200
         # Service name is automatically requested, so we need to mock that response
-        mock_requests.get.return_value = mock_response
-        mock_requests.post.return_value = mock_response
+        mock_response_service.status_code = 200
+        mock_requests.get.return_value = mock_response_service
         connection = EmpowerConnection(
             project="test_project",
             address="http://test_address/",
@@ -55,19 +53,18 @@ class TestEmpowerConnection(unittest.TestCase):
 
     @patch("OptiHPLCHandler.empower_api_core.requests")
     def test_automatic_service_name(self, mock_requests):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "results": [{"netServiceName": "automatic_test_service"}],
-            "result": {"token": "test_token"},
+        mock_response_service = MagicMock()
+        mock_response_service.json.return_value = {
+            "results": [{"netServiceName": "auto_test_service"}]
         }
-        mock_response.status_code = 200
-        mock_requests.get.return_value = mock_response
-        mock_requests.post.return_value = mock_response
+        # Service name is automatically requested, so we need to mock that response
+        mock_response_service.status_code = 200
+        mock_requests.get.return_value = mock_response_service
         connection = EmpowerConnection(
             address="http://test_address/",
             project="test_project",
         )
-        assert connection.service == "automatic_test_service"
+        assert connection.service == "auto_test_service"
 
     @patch("OptiHPLCHandler.empower_api_core.requests")
     def test_get(self, mock_requests):

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -10,7 +10,7 @@ class TestEmpowerConnection(unittest.TestCase):
     def setUp(self, mock_requests) -> None:
         mock_response = MagicMock()
         mock_response.json.return_value = {
-            "results": [{"token": "test_token", "id": "test_id"}]
+            "result": [{"token": "test_token", "id": "test_id"}]
         }
         mock_response.status_code = 200
         mock_requests.post.return_value = mock_response
@@ -32,7 +32,8 @@ class TestEmpowerConnection(unittest.TestCase):
     def test_auto_service(self, mock_requests):
         mock_response = MagicMock()
         mock_response.json.return_value = {
-            "results": [{"netServiceName": "auto_test_service", "token": "test_token"}]
+            "results": [{"netServiceName": "auto_test_service"}],
+            "result": {"token": "test_token"},
         }
         mock_response.status_code = 200
         # Service name is automatically requested, so we need to mock that response
@@ -56,9 +57,8 @@ class TestEmpowerConnection(unittest.TestCase):
     def test_automatic_service_name(self, mock_requests):
         mock_response = MagicMock()
         mock_response.json.return_value = {
-            "results": [
-                {"netServiceName": "automatic_test_service", "token": "test_token"}
-            ]
+            "results": [{"netServiceName": "auto_test_service"}],
+            "result": {"token": "test_token"},
         }
         mock_response.status_code = 200
         mock_requests.get.return_value = mock_response
@@ -95,7 +95,7 @@ class TestEmpowerConnection(unittest.TestCase):
     def test_relogin_get(self, mock_requests, mock_getpass):
         # Verify that the handler logs in again if the token is invalid on get.
         mock_response = MagicMock()
-        mock_response.json.return_value = {"results": [{"token": "test_token"}]}
+        mock_response.json.return_value = {"result": [{"token": "test_token"}]}
         mock_response.status_code = 401
         mock_requests.get.return_value = mock_response
         mock_response = MagicMock()
@@ -136,7 +136,7 @@ class TestEmpowerConnection(unittest.TestCase):
         # Verify that the handler logs in again if the token is invalid on put.
         mock_response = MagicMock()
         mock_response.json.return_value = {
-            "results": [{"token": "test_token", "id": "test_id"}]
+            "result": [{"token": "test_token", "id": "test_id"}]
         }
         mock_response.status_code = 401
         mock_requests.post.return_value = mock_response

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -57,7 +57,7 @@ class TestEmpowerConnection(unittest.TestCase):
     def test_automatic_service_name(self, mock_requests):
         mock_response = MagicMock()
         mock_response.json.return_value = {
-            "results": [{"netServiceName": "auto_test_service"}],
+            "results": [{"netServiceName": "automatic_test_service"}],
             "result": {"token": "test_token"},
         }
         mock_response.status_code = 200

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -10,7 +10,7 @@ class TestEmpowerConnection(unittest.TestCase):
     def setUp(self, mock_requests) -> None:
         mock_response = MagicMock()
         mock_response.json.return_value = {
-            "result": [{"token": "test_token", "id": "test_id"}]
+            "result": {"token": "test_token", "id": "test_id"}
         }
         mock_response.status_code = 200
         mock_requests.post.return_value = mock_response
@@ -95,7 +95,7 @@ class TestEmpowerConnection(unittest.TestCase):
     def test_relogin_get(self, mock_requests, mock_getpass):
         # Verify that the handler logs in again if the token is invalid on get.
         mock_response = MagicMock()
-        mock_response.json.return_value = {"result": [{"token": "test_token"}]}
+        mock_response.json.return_value = {"result": {"token": "test_token"}}
         mock_response.status_code = 401
         mock_requests.get.return_value = mock_response
         mock_response = MagicMock()
@@ -136,7 +136,7 @@ class TestEmpowerConnection(unittest.TestCase):
         # Verify that the handler logs in again if the token is invalid on put.
         mock_response = MagicMock()
         mock_response.json.return_value = {
-            "result": [{"token": "test_token", "id": "test_id"}]
+            "result": {"token": "test_token", "id": "test_id"}
         }
         mock_response.status_code = 401
         mock_requests.post.return_value = mock_response


### PR DESCRIPTION
Fixes login for API version 2.1.0.1

We could make it flexible, so new version of OptiHPLCHandler work with both old and new Empower Web API versions, but I think this is the better approach.