### PR TITLE
feat: Several solvent line can be given in one string

### DIFF
--- a/src/OptiHPLCHandler/empower_instrument_method.py
+++ b/src/OptiHPLCHandler/empower_instrument_method.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import List, Optional, Union
 
 from OptiHPLCHandler.data_types import EmpowerInstrumentMethodModel as DataModel
@@ -135,7 +136,8 @@ class EmpowerInstrumentMethod:
     def valve_position(self):
         """
         The valve position for the solvent manager, if a solvent manager module method
-        is present.
+        is present. When setting, can be a list of valve positions (e.g. ["A1", "B2"]),
+        or a string containing one or more valve positions, (e.g. "A1, B2").
         """
         if self.solvent_handler_method is None:
             raise ValueError(
@@ -145,12 +147,20 @@ class EmpowerInstrumentMethod:
         return self.solvent_handler_method.valve_position
 
     @valve_position.setter
-    def valve_position(self, valve_position: str):
+    def valve_position(self, valve_position: Union[str, List[str]]):
         if self.solvent_handler_method is None:
             raise ValueError(
                 "Can't set valve position, "
                 "no solvent manager found in instrument method."
             )
+        if isinstance(valve_position, str):
+            valve_position = [i[0] for i in re.finditer(r"[A-D]\d", valve_position)]
+            # Make a list of every instance of XY in the string, where X is A, B, C
+            # or D, and Y is a digit (0-9). These are presumed to be valve positions.
+            if len(valve_position) == 0:
+                raise ValueError(
+                    f"Found nothing that could be a valve position in {valve_position}"
+                )
         self.solvent_handler_method.valve_position = valve_position
 
     def __str__(self):

--- a/tests/test_instrument_method.py
+++ b/tests/test_instrument_method.py
@@ -209,11 +209,11 @@ class TestSolventManager(unittest.TestCase):
     def setUp(self) -> None:
         self.example = get_example_file_dict()
         self.bsm_example = self.example["response-BSM-PDA-Acq.json"]
+        self.method = EmpowerInstrumentMethod(self.bsm_example)
 
     def test_init(self):
-        method = EmpowerInstrumentMethod(self.bsm_example)
-        assert method.solvent_handler_method is not None
-        assert isinstance(method.solvent_handler_method, SolventManagerMethod)
+        assert self.method.solvent_handler_method is not None
+        assert isinstance(self.method.solvent_handler_method, SolventManagerMethod)
 
     def test_init_none(self):
         method_definition = self.bsm_example["results"][0]
@@ -228,8 +228,7 @@ class TestSolventManager(unittest.TestCase):
             EmpowerInstrumentMethod(method_definition)
 
     def test_get_gradient_table(self):
-        method = EmpowerInstrumentMethod(self.bsm_example)
-        gradient_table = method.gradient_table
+        gradient_table = self.method.gradient_table
         assert isinstance(gradient_table, list)
         assert isinstance(gradient_table[0], dict)
 
@@ -241,16 +240,18 @@ class TestSolventManager(unittest.TestCase):
             method.gradient_table
 
     def test_set_gradient_table(self):
-        method = EmpowerInstrumentMethod(self.bsm_example)
-        gradient_table = method.gradient_table
+        gradient_table = self.method.gradient_table
         assert gradient_table[0]["Flow"] != "0.1"
         assert (
-            "<Flow>0.1</Flow>" not in method.current_method["modules"][1]["nativeXml"]
+            "<Flow>0.1</Flow>"
+            not in self.method.current_method["modules"][1]["nativeXml"]
         )
         gradient_table[0]["Flow"] = "0.1"
-        method.gradient_table = gradient_table
-        assert method.gradient_table[0]["Flow"] == "0.1"
-        assert "<Flow>0.1</Flow>" in method.current_method["modules"][1]["nativeXml"]
+        self.method.gradient_table = gradient_table
+        assert self.method.gradient_table[0]["Flow"] == "0.1"
+        assert (
+            "<Flow>0.1</Flow>" in self.method.current_method["modules"][1]["nativeXml"]
+        )
 
     def test_set_gradient_table_none(self):
         method_definition = self.bsm_example["results"][0]
@@ -264,10 +265,10 @@ class TestValvePosition(unittest.TestCase):
     def setUp(self) -> None:
         self.example = get_example_file_dict()
         self.bsm_example = self.example["response-BSM-PDA-Acq.json"]
+        self.method = EmpowerInstrumentMethod(self.bsm_example)
 
     def test_get(self):
-        method = EmpowerInstrumentMethod(self.bsm_example)
-        assert method.valve_position == ["A1", "B1"]
+        assert self.method.valve_position == ["A1", "B1"]
 
     def test_get_none(self):
         method_definition = self.bsm_example["results"][0]
@@ -276,27 +277,52 @@ class TestValvePosition(unittest.TestCase):
         with self.assertRaises(ValueError):
             method.valve_position
 
-    def test_set(self):
-        method = EmpowerInstrumentMethod(self.bsm_example)
-        method.valve_position = "A2"
-        assert method.valve_position == ["A2", "B1"]
+    def test_set_list_one(self):
+        self.method.valve_position = ["A2"]
+        assert self.method.valve_position == ["A2", "B1"]
         assert (
             "<FlowSourceA>2</FlowSourceA>"
-            in method.current_method["modules"][1]["nativeXml"]
+            in self.method.current_method["modules"][1]["nativeXml"]
         )
         assert (
             "<FlowSourceB>1</FlowSourceB>"
-            in method.current_method["modules"][1]["nativeXml"]
+            in self.method.current_method["modules"][1]["nativeXml"]
         )
-        method.valve_position = ["A7", "B5"]
-        assert method.valve_position == ["A7", "B5"]
+
+    def test_set_list_multiple(self):
+        self.method.valve_position = ["A7", "B5"]
+        assert self.method.valve_position == ["A7", "B5"]
         assert (
             "<FlowSourceA>7</FlowSourceA>"
-            in method.current_method["modules"][1]["nativeXml"]
+            in self.method.current_method["modules"][1]["nativeXml"]
         )
         assert (
             "<FlowSourceB>5</FlowSourceB>"
-            in method.current_method["modules"][1]["nativeXml"]
+            in self.method.current_method["modules"][1]["nativeXml"]
+        )
+
+    def test_set_str_single(self):
+        self.method.valve_position = "A2"
+        assert self.method.valve_position == ["A2", "B1"]
+        assert (
+            "<FlowSourceA>2</FlowSourceA>"
+            in self.method.current_method["modules"][1]["nativeXml"]
+        )
+        assert (
+            "<FlowSourceB>1</FlowSourceB>"
+            in self.method.current_method["modules"][1]["nativeXml"]
+        )
+
+    def test_set_str_multiple(self):
+        self.method.valve_position = "A2, B3"
+        assert self.method.valve_position == ["A2", "B3"]
+        assert (
+            "<FlowSourceA>2</FlowSourceA>"
+            in self.method.current_method["modules"][1]["nativeXml"]
+        )
+        assert (
+            "<FlowSourceB>3</FlowSourceB>"
+            in self.method.current_method["modules"][1]["nativeXml"]
         )
 
     def test_set_none(self):
@@ -309,8 +335,7 @@ class TestValvePosition(unittest.TestCase):
             method.valve_position = ["A2", "B1"]
 
     def test_method_name(self):
-        method = EmpowerInstrumentMethod(self.bsm_example)
-        assert method.method_name == "AcquityBSMPDA"
-        method.method_name = "new_name"
-        assert method.method_name == "new_name"
-        assert method.current_method["methodName"] == "new_name"
+        assert self.method.method_name == "AcquityBSMPDA"
+        self.method.method_name = "new_name"
+        assert self.method.method_name == "new_name"
+        assert self.method.current_method["methodName"] == "new_name"

--- a/tests/test_module_method.py
+++ b/tests/test_module_method.py
@@ -391,28 +391,6 @@ class testQSMMethod(unittest.TestCase):
             "<SolventSelectionValveDPosition>2</SolventSelectionValveDPosition>"
             in module_method.current_method["nativeXml"]
         )
-        module_method.valve_position = "D1"
-        assert module_method.valve_position == ["A0", "B0", "C0", "D1"]
-        assert "A0" in str(module_method)
-        assert "B0" in str(module_method)
-        assert "C0" in str(module_method)
-        assert "D1" in str(module_method)
-        assert (
-            "<SolventSelectionValveAPosition>0</SolventSelectionValveAPosition>"
-            in module_method.current_method["nativeXml"]
-        )
-        assert (
-            "<SolventSelectionValveBPosition>0</SolventSelectionValveBPosition>"
-            in module_method.current_method["nativeXml"]
-        )
-        assert (
-            "<SolventSelectionValveCPosition>0</SolventSelectionValveCPosition>"
-            in module_method.current_method["nativeXml"]
-        )
-        assert (
-            "<SolventSelectionValveDPosition>1</SolventSelectionValveDPosition>"
-            in module_method.current_method["nativeXml"]
-        )
 
     def test_gradient_table(self):
         module_method = QSMMethod(self.minimal_definition)
@@ -885,16 +863,6 @@ class testBSMMethod(unittest.TestCase):
         assert "B2" in str(module_method)
         assert (
             "<FlowSourceA>2</FlowSourceA>" in module_method.current_method["nativeXml"]
-        )
-        assert (
-            "<FlowSourceB>2</FlowSourceB>" in module_method.current_method["nativeXml"]
-        )
-        module_method.valve_position = "A1"
-        assert module_method.valve_position == ["A1", "B2"]
-        assert "A1" in str(module_method)
-        assert "B2" in str(module_method)
-        assert (
-            "<FlowSourceA>1</FlowSourceA>" in module_method.current_method["nativeXml"]
         )
         assert (
             "<FlowSourceB>2</FlowSourceB>" in module_method.current_method["nativeXml"]


### PR DESCRIPTION
You can now give the command `EmpowerInstrumentMethod.solvent_lines = "A1, B2"`, and two solvent line will be set.

Removed the ability of `SolventManagerMethod` to take `str`, it now only takes a `List[str]`. So you can feed either a string or a list of strings to  `EmpowerInstrumentMethod.solvent_lines`, but only a list of strings to  `SolventManagerMethod.solvent_lines`.