### PR TITLE
Refresh token

### DIFF
--- a/src/OptiHPLCHandler/empower_api_core.py
+++ b/src/OptiHPLCHandler/empower_api_core.py
@@ -155,7 +155,7 @@ class EmpowerConnection:
         logger.debug("Logout successful")
 
     def _requests_wrapper(
-        self, method: str, endpoint: str, body: Optional[dict], timeout
+        self, method: str, endpoint: str, body: Optional[dict], timeout: int
     ) -> Tuple[Optional[dict], Optional[str]]:
         """
         Wrapper for requests.
@@ -168,11 +168,20 @@ class EmpowerConnection:
         :return: The results and message from the response.
         """
 
-        def _request_with_timeout(method, endpoint, header, body, timeout, verify):
+        def _request_with_timeout(
+            method: str,
+            endpoint: str,
+            params: dict,
+            header: dict,
+            body: dict,
+            timeout: int,
+            verify: Union[bool, str],
+        ) -> requests.Response:
             try:
                 return requests.request(
                     method,
                     endpoint,
+                    params=params,
                     json=body,
                     headers=header,
                     timeout=timeout,
@@ -183,18 +192,43 @@ class EmpowerConnection:
                     f"{method}ing {body} to {endpoint} timed out"
                 ) from e
 
+        if self.api_version != "1.0":
+            raise ValueError("Only API version 1.0 is supported")
+            # Update the ["results"] when refreshing token to make it work.
         endpoint = endpoint.lstrip("/")  # Remove leading slash if present
         address = self.address + "/" + endpoint
         # Add slash between address and endpoint
         logger.debug("%sing %s to %s", method, body, address)
         response = _request_with_timeout(
-            method, address, self.header, body, timeout, self.verify
+            method=method,
+            endpoint=address,
+            header=self.header,
+            body=body,
+            timeout=timeout,
+            verify=self.verify,
+            params={},
         )
         if response.status_code == 401:
-            logger.debug("Token expired, logging in again")
-            self.login()
+            logger.debug("Token expired, refreshing token and %sing again", method)
+            refresh_response = _request_with_timeout(
+                method="get",
+                endpoint=self.address + "/authentication/refresh-token",
+                header=self.header,
+                body=None,
+                timeout=self.default_get_timeout,
+                verify=self.verify,
+                params={"sessionInfoID": self.session_id},
+            )
+            self.raise_for_status(refresh_response)
+            self.token = refresh_response.json()["results"][0]["token"]
             response = _request_with_timeout(
-                method, address, self.header, body, timeout, self.verify
+                method=method,
+                endpoint=address,
+                header=self.header,
+                body=body,
+                timeout=timeout,
+                verify=self.verify,
+                params={},
             )
         logger.debug("Got response %s from %s", response.text, address)
         self.raise_for_status(response)
@@ -281,7 +315,10 @@ class EmpowerConnection:
     @property
     def header(self):
         """Get the authorization header to use for requests."""
-        return {"Authorization": "Bearer " + self.token, "api-version": self.api_version}
+        return {
+            "Authorization": "Bearer " + self.token,
+            "api-version": self.api_version,
+        }
 
     def __del__(self):
         if self.session_id is not None:

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -158,7 +158,8 @@ class TestEmpowerConnection(unittest.TestCase):
         mock_getpass.return_value = self.mock_password
         self.connection.get("test_url")
         assert mock_requests.method_calls[1].args == (
-            "https://test_address/authentication/login",
+            "get",
+            "https://test_address/authentication/refresh-token",
         )
         # The second call should be to log in
 
@@ -198,7 +199,8 @@ class TestEmpowerConnection(unittest.TestCase):
         mock_getpass.return_value = self.mock_password
         self.connection.post("test_url", body="test_body")
         assert mock_requests.method_calls[1].args == (
-            "https://test_address/authentication/login",
+            "get",
+            "https://test_address/authentication/refresh-token",
         )
         # The second call should be to log in
 


### PR DESCRIPTION
I've made it stop if any API version other than 1.0 is used, but also written what needs to be fixed. It should be pretty self-explanatory from what happens with different API versions.