### PR TITLE
Allow for unpickling

### DIFF
--- a/src/OptiHPLCHandler/utils/data_types.py
+++ b/src/OptiHPLCHandler/utils/data_types.py
@@ -93,7 +93,9 @@ class OptiDict(dict):
         self.mutable = mutable
 
     def __setitem__(self, __key: Any, __value: Any) -> None:
-        if self.mutable:
+        if getattr(self, "mutable", True):
+            # un-pickling does not call __init__, so mutable is not set when unpickling
+            # Therefore, we need to allow for mutable not being set
             return super().__setitem__(__key, __value)
         raise TypeError("Object is immutable")
 


### PR DESCRIPTION
Unpickling doesn't invoke `__init__`, it seems to just set the attributes directly.

This mucks up with the way we made `OptiDict`'s immutable by overloading `__setitem__`, since it checks `self.mutable` which is set in `__init__`.

As a work-around, we allow for a default value for `self.mutable` in `__setitem__`