### PR TITLE
fix: Data type in component fields

### DIFF
--- a/src/OptiHPLCHandler/empower_handler.py
+++ b/src/OptiHPLCHandler/empower_handler.py
@@ -245,10 +245,12 @@ class EmpowerHandler:
                             {
                                 "name": "Component",
                                 "value": component_name,
+                                "dataType": "String",
                             },
                             {
                                 "name": "Value",
                                 "value": component_value,
+                                "dataType": "Double",
                             },
                         ],
                     }

--- a/tests/test_proxy_api.py
+++ b/tests/test_proxy_api.py
@@ -334,10 +334,14 @@ class TestSampleList(unittest.TestCase):
             "sampleSetLines"
         ]
         components = sample_set_lines[0]["components"]
-        assert {"name": "Component", "value": "test_component_name_1"} in components[0][
+        assert {
+            "name": "Component",
+            "value": "test_component_name_1",
+            "dataType": "String",
+        } in components[0]["fields"]
+        assert {"name": "Value", "value": 1, "dataType": "Double"} in components[0][
             "fields"
         ]
-        assert {"name": "Value", "value": 1} in components[0]["fields"]
         assert {
             "name": "Components",
             "value": "test_custom_field_value",

--- a/tests/test_proxy_api.py
+++ b/tests/test_proxy_api.py
@@ -302,9 +302,13 @@ class TestSampleList(unittest.TestCase):
         components = sample_set_lines[0]["components"]
         assert components[0]["id"] != components[1]["id"]
         for i, (name, concentration) in enumerate(component_dict.items()):
-            name_dict = {"name": "Component", "value": name}
+            name_dict = {"name": "Component", "value": name, "dataType": "String"}
             assert name_dict in components[i]["fields"]
-            concentration_dict = {"name": "Value", "value": concentration}
+            concentration_dict = {
+                "name": "Value",
+                "value": concentration,
+                "dataType": "Double",
+            }
             assert concentration_dict in components[i]["fields"]
 
     def test_component_key(self):


### PR DESCRIPTION
This used to work without it, but now we get errors when we push components without data type.